### PR TITLE
Add Support for the cheap RM4 TV mate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Python module and CLI for controlling Broadlink devices locally. The following devices are supported:
 
-- **Universal remotes**: RM home, RM mini 3, RM plus, RM pro, RM pro+, RM4 mini, RM4 pro, RM4C mini, RM4S
+- **Universal remotes**: RM home, RM mini 3, RM plus, RM pro, RM pro+, RM4 mini, RM4 pro, RM4C mini, RM4S, RM4 TV mate
 - **Smart plugs**: SP mini, SP mini 3, SP mini+, SP1, SP2, SP2-BR, SP2-CL, SP2-IN, SP2-UK, SP3, SP3-EU, SP3S-EU, SP3S-US, SP4L-AU, SP4L-EU, SP4L-UK, SP4M, SP4M-US, Ankuoo NEO, Ankuoo NEO PRO, Efergy Ego, BG AHC/U-01
 - **Switches**: MCB1, SC1, SCB1E, SCB2
 - **Outlets**: BG 800, BG 900

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -120,6 +120,7 @@ SUPPORTED_TYPES = {
         0x648D: ("RM4 mini", "Broadlink"),
         0x6539: ("RM4C mini", "Broadlink"),
         0x653A: ("RM4 mini", "Broadlink"),
+        0x5209: ("RM4 TV mate", "Broadlink"),
     },
     rm4pro: {
         0x6026: ("RM4 pro", "Broadlink"),


### PR DESCRIPTION
## Context
I purchased the cheap RM4 TV mate from Amazon in an attempt to you use it with Home Assistant. The existing 0.18.0 release does not support it. I added the device code as a rm4mini and the devices works with the device methods.

Here is a link to the device on amazon:

https://www.amazon.com/gp/product/B096SNKY38

I forked the default Broadlink Home Assistant component integration and had my requirements metadata point to my forked github repo. The device was discovered properly and leaning and sending codes works as documented in Home Assistant.


## Proposed change
module __initi__.py added device code `0x5209` to the `rm4mini` device type.

changed the README to include the RM4 TV mate as supported.


## Type of change
<!--
  What type of change does your PR introduce?
  Please, check only 1 box!
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X ] New device
- [X] New product id (the device is already supported with a different id)
- [ ] New feature (which adds functionality to an existing device)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [X] Documentation

## Additional information
<!--
  Link docs and related issues, when applicable.
-->

- This PR fixes issue: fixes #
- This PR is related to: 
- Link to documentation pull request: 

## Checklist
<!--
  Please do your best to check these boxes.
-->

- [X] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [X] The code follows the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).
- [X] I am creating the Pull Request against the correct branch.
- [X] Documentation added/updated.
